### PR TITLE
Add ref bias calculation

### DIFF
--- a/.test/config/config.yaml
+++ b/.test/config/config.yaml
@@ -47,6 +47,7 @@ analyses:
   population_missing_data: 0.5
   # quality control
   qualimap: true
+  ibs_ref_bias: true
   damageprofiler: true
   mapdamage_rescale: false
   # population genomic analyses

--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ accessions from e.g. NCBI/ENA.
   DamageProfiler[^8]
 - Clipping of overlapping mapped paired end reads using BamUtil[^9]
 - Quality control information from fastp, Qualimap[^10], DamageProfiler, and
-  MapDamage2 (Qualimap is also available for users starting with BAM files)
+  MapDamage2 (Only Qualimap is available for samples starting from user-provided
+  BAMs). Additionally, several filtered and unfiltered depth statistics as well
+  as reference bias are calculated using ANGSD.
 
 ### Population Genomics
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -47,6 +47,7 @@ analyses:
   population_missing_data:
   # quality control
   qualimap: true
+  ibs_ref_bias: true
   damageprofiler: true
   mapdamage_rescale: true
   # population genomic analyses

--- a/docs/config.md
+++ b/docs/config.md
@@ -251,6 +251,13 @@ settings for each analysis are set in the next section.
     group/sample. This is how most papers do it.)
   - `qualimap:` Perform Qualimap bamqc on bam files for general quality stats
     (`true`/`false`)
+  - `ibs_ref_bias:` Enable reference bias calculation. For each sample, one read
+    is randomly sampled at each position and compared to the reference base.
+    These are summarized as the proportion of the genome that is identical by
+    state to the reference for each sample to quantify reference bias. This is
+    done for all filter sets as well as for all sites without site filtering.
+    If transition removal or other arguments are passed to ANGSD, they are
+    included here. (`true`/`false`)
   - `damageprofiler:` Estimate post-mortem DNA damage on historical samples
     with Damageprofiler (`true`/`false`) NOTE: This just adds the addition of
     Damageprofiler to the already default output of MapDamage.

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -63,6 +63,8 @@ wildcard_constraints:
 
 # Accumulate desired output files from config file
 
+# Quality control
+
 all_outputs = [
     "results/datasets/{dataset}/qc/{dataset}.{ref}_all.sampleqc.html",
     "results/datasets/{dataset}/filters/combined/{dataset}.{ref}_{sites}-filts.html",
@@ -95,6 +97,16 @@ if len(pipebams) > 0:
 if config["analyses"]["qualimap"]:
     all_outputs.append(
         "results/datasets/{dataset}/qc/qualimap/qualimap_all.{ref}_mqc.html",
+    )
+
+
+if config["analyses"]["ibs_ref_bias"]:
+    all_outputs.extend(
+        expand(
+            "results/datasets/{{dataset}}/qc/ibs_refbias/{{dataset}}.{{ref}}_all{dp}_{filts}.refibs.html",
+            filts=["allsites-unfilt", "{sites}-filts"],
+            dp=subsample,
+        )
     )
 
 

--- a/workflow/scripts/plot_ref_bias.R
+++ b/workflow/scripts/plot_ref_bias.R
@@ -1,0 +1,41 @@
+sink(file(snakemake@log[[1]], open="wt"), type = "message")
+
+library(dplyr)
+library(ggplot2)
+
+
+ibstable_raw <- read.table(snakemake@input[["ibs"]], sep = "\t", header = TRUE)
+poplist <- read.table(snakemake@input[["pops"]], sep = "\t", header = TRUE)
+plotpre <- snakemake@params[["plotpre"]]
+
+ibstable <- merge(ibstable_raw, poplist, by = "sample")
+
+ggplot(ibstable, aes(x = population, y = ibs.to.ref)) +
+  geom_boxplot(outlier.shape = NA) +
+  geom_jitter(position=position_jitter(0.2)) +
+  ylab("Proportion sites identical to reference") +
+  xlab("Population") +
+  theme_classic()
+
+ggsave(paste0(plotpre, ".population.svg"))
+
+ggplot(ibstable, aes(x = time, y = ibs.to.ref)) +
+  geom_boxplot(outlier.shape = NA) +
+  geom_jitter(position=position_jitter(0.2)) +
+  ylab("Proportion sites identical to reference") +
+  xlab("Time Period") +
+  theme_classic()
+
+ggsave(paste0(plotpre, ".time.svg"))
+
+ggplot(ibstable, aes(x = depth, y = ibs.to.ref)) +
+  geom_boxplot(outlier.shape = NA) +
+  geom_jitter(position=position_jitter(0.2)) +
+  ylab("Proportion sites identical to reference") +
+  xlab("Depth Class") +
+  theme_classic()
+
+ggsave(paste0(plotpre, ".depth.svg"))
+
+write.table(ibstable, file = snakemake@output[["table"]], quote=FALSE,
+  sep = '\t', row.names = FALSE)


### PR DESCRIPTION
Adds a simple calculation of reference bias. For each site, a read is randomly sampled and compared to the reference and given a value of 0 (differs) or 1 (identical). These are averaged across the genome to get a measure of the proportion of the genome that is identical to the reference. This can be used to assess reference bias. Performed for all filtered sites list as well as for all sites without site filtering (but still includes mapQ and baseQ filtering, as well as any 'extra' filters passed to ANGSD in the config).

If enabled, mapdamage rescaling is done before this calculation. Similarly, if transition removal is enabled, sites where the sampled read would suggest a transition compared to the reference are ignored.

Closes #43.