### PR TITLE
Fix: Make it so that bamlist generation is re-run if sample order changes, keeping meta-data consistent

### DIFF
--- a/workflow/rules/3.0_genotype_likelihoods.smk
+++ b/workflow/rules/3.0_genotype_likelihoods.smk
@@ -19,10 +19,14 @@ rule angsd_makeBamlist:
         "logs/datasets/{dataset}/bamlists/{dataset}.{ref}_{population}{dp}.log",
     container:
         shell_container
+    params:
+        sampord=lambda w, input: f"{input.bams}",
     shell:
         """
-        (readlink -f {input.bams} > {output}
-        truncate -s -1 {output}) 2> {log}
+        (
+        echo "BAM order: {params.sampord}" > {log}
+        readlink -f {input.bams} > {output} 2>> {log}
+        truncate -s -1 {output}) 2>> {log}
         """
 
 


### PR DESCRIPTION
If sample order changed in the samples.tsv after a completed run, and a new run was made, poplists would be re-generated, but not bamlists, which would cause samples info to line up with the wrong samples in the beagle files. Now, the bamlist will also be generated. This is not the most efficient way to handle this, as it will trigger many re-runs, but it seems a safe way without changing how GL files are made in the workflow. This should only trigger when samples are being changed anyway, so re-runs are mostly going to be desired anyway.

Closes #48.