### PR TITLE
Separate extra params for paired and merged fastp processing

### DIFF
--- a/.test/config/config.yaml
+++ b/.test/config/config.yaml
@@ -121,7 +121,8 @@ params:
   clipoverlap:
     clip_user_provided_bams: true
   fastp:
-    extra: "-p -g" # don't put --merge or --overlap_len_require here, they're implicit
+    merged_extra: "-p -g" # don't put --merge or --overlap_len_require here, they're implicit
+    paired_extra: "-p -g"
     min_overlap_hist: 20
   bwa_aln:
     extra: "-l 16500 -n 0.01 -o 2"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -119,7 +119,8 @@ params:
   clipoverlap:
     clip_user_provided_bams: false
   fastp:
-    extra: "-p -g" # don't put --merge or --overlap_len_require here, they're implicit
+    merged_extra: "-p -g" # don't put --merge or --overlap_len_require here, they're implicit
+    paired_extra: "-p -g"
     min_overlap_hist: 30
   bwa_aln:
     extra: "-l 16500 -n 0.01 -o 2"

--- a/workflow/rules/1.0_preprocessing.smk
+++ b/workflow/rules/1.0_preprocessing.smk
@@ -50,7 +50,7 @@ rule fastp_mergedout:
     benchmark:
         "benchmarks/preprocessing/fastp/{sample}_{unit}_{lib}.merged.log"
     params:
-        extra=lambda w: config["params"]["fastp"]["extra"]
+        extra=lambda w: config["params"]["fastp"]["merged_extra"]
         + f" --merge --overlap_len_require {config['params']['fastp']['min_overlap_hist']}",
     threads: lambda wildcards, attempt: attempt * 2
     resources:
@@ -87,7 +87,7 @@ rule fastp_pairedout:
     benchmark:
         "benchmarks/preprocessing/fastp/{sample}_{unit}_{lib}.paired.log"
     params:
-        extra=lambda w: config["params"]["fastp"]["extra"],
+        extra=lambda w: config["params"]["fastp"]["paired_extra"],
     threads: lambda wildcards, attempt: attempt * 2
     resources:
         runtime=lambda wildcards, attempt: attempt * 480,


### PR DESCRIPTION
Sometimes it might be useful to do some different things there, like trimming damaged ends in merged reads but not paired.